### PR TITLE
add npmRun.sync() method

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,15 @@
 "use strict"
 
-var which = require('npm-which')
 var npmPath = require('npm-path')
 var child_process = require('child_process')
 
 var exec = child_process.exec
+var execSync = child_process.execSync
 var execFile = child_process.execFile
 var spawn = child_process.spawn
 var fork = child_process.fork
 npmExec.spawn = npmSpawn
+npmExec.sync = npmExecSync
 
 module.exports = npmExec
 
@@ -20,6 +21,12 @@ function npmExec(args, options, fn) {
     if (err) return fn(err)
     exec(args, options, fn)
   })
+}
+
+function npmExecSync(args, options) {
+  var opts = setOptions(options)
+  var path = getPath.sync(opts[0])
+  return execSync(args, path).toString()
 }
 
 function npmSpawn() {

--- a/test/exec.js
+++ b/test/exec.js
@@ -78,4 +78,31 @@ test('includes all .bin dirs in all parent node_modules folders', function(t) {
   t.end()
 })
 
+test('sync', function(t) {
+  t.test('no nesting', function(t) {
+    var stdout = npmRun.sync('level1', {cwd: level[0]})
+    t.equal(stdout.trim(), 'level1')
+    t.end()
+  })
+
+  t.test('nesting', function(t) {
+    var stdout = npmRun.sync('level1', {cwd: level[1]})
+    t.equal(stdout.trim(), 'level1')
+
+    stdout = npmRun.sync('level2', {cwd: level[1]})
+    t.equal(stdout.trim(), 'level2')
+    t.end()
+  })
+
+  t.test('more nesting', function(t) {
+    var stdout = npmRun.sync('level1', {cwd: level[2]})
+    t.equal(stdout.trim(), 'level1')
+
+    stdout = npmRun.sync('level2', {cwd: level[2]})
+    t.equal(stdout.trim(), 'level2')
+    t.end()
+  })
+
+  t.end()
+})
 


### PR DESCRIPTION
in some cases it's very useful to support the sync API (eg. build tools)

I'm planning to use this to implement the [`pipe` feature on esformatter](https://github.com/millermedeiros/esformatter/issues/168).

this saved me many hours of work! thanks for writing this tool.