### PR TITLE
update sync-exec to latest version (license change)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "npm-which": "^2.0.0",
     "serializerr": "^1.0.1",
     "spawn-sync": "^1.0.5",
-    "sync-exec": "^0.5.0"
+    "sync-exec": "^0.6.2"
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
The sync-exec module used to be licensed GPL, but is now MIT.  (https://github.com/gvarsanyi/sync-exec/commit/75a2c1011bb0c75b9f5e983db8742a942cfc9fcb).

Update to the latest version to support the more permissive license.