### PR TITLE
Support Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 var npmPath = require('npm-path')
 var child_process = require('child_process')
 var syncExec = require('sync-exec')
+var spawn = require('cross-spawn')
 
 var exec = child_process.exec
 
@@ -12,7 +13,6 @@ var execSync = child_process.execSync || function(args, path) {
 }
 
 var execFile = child_process.execFile
-var spawn = child_process.spawn
 var fork = child_process.fork
 
 npmExec.spawn = npmSpawn
@@ -45,7 +45,7 @@ function npmSpawnSync(command, args, options) {
   command = a[0]
   args = a[1]
   options = a[2]
-  return child_process.spawnSync(command, args, augmentOptionsSync(options))
+  return spawn.sync(command, args, augmentOptionsSync(options))
 }
 
 function npmExecSync(command, options) {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "tape": "^3.5.0"
   },
   "dependencies": {
+    "cross-spawn": "^2.1.5",
     "minimist": "^1.1.1",
     "npm-path": "^1.0.1",
     "npm-which": "^2.0.0",


### PR DESCRIPTION
### Problem
`.spawn()` doesn't work on Windows properly because it ignores PATHEXT. `.exec()` is ok.
I get the following error when I execute `npm-run mocha` on Windows.

```
$ npm-run mocha
Error: spawn mocha ENOENT
    at exports._errnoException (util.js:856:11)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:178:32)
    at onErrorNT (internal/child_process.js:344:16)
    at nextTickCallbackWith2Args (node.js:478:9)
    at process._tickCallback (node.js:392:17)
    at Function.Module.runMain (module.js:432:11)
    at startup (node.js:141:18)
    at node.js:1003:3
```

### Solution
Use **[cross-spawn](https://github.com/IndigoUnited/node-cross-spawn)** instead.

I tested my code on AppVeyor just in case.
https://ci.appveyor.com/project/htanjo/npm-run/build/1.0.5

If you need the [test config/fixtures](https://github.com/htanjo/npm-run/commit/9139583d54f71938205bf634f24784a9ba154b25), I'll include it in this PR.