### PR TITLE
Options for exec is optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function npmExec (command, options, fn) {
   var a = normalizeExecArgs(command, options, fn)
   command = a[0]
   options = a[1]
-  fn = a[2];
+  fn = a[2]
   return exec(command, augmentOptionsSync(options), fn)
 }
 

--- a/index.js
+++ b/index.js
@@ -22,9 +22,10 @@ npmExec.execSync = npmExecSync
 module.exports = npmExec
 
 function npmExec (command, options, fn) {
-  var a = normalizeExecArgs(command, options)
+  var a = normalizeExecArgs(command, options, fn)
   command = a[0]
   options = a[1]
+  fn = a[2];
   return exec(command, augmentOptionsSync(options), fn)
 }
 

--- a/test/exec.js
+++ b/test/exec.js
@@ -30,6 +30,16 @@ test('passing args', function (t) {
   })
 })
 
+test('options are optional', function (t) {
+  var badPath = 'not-exist-adsjk'
+
+  npmRun(badPath, function (err, stdout, stderr) {
+    t.ok(err, 'has error')
+    t.equal(err.code, 127)
+    t.end()
+  })
+})
+
 test('includes all .bin dirs in all parent node_modules folders', function (t) {
   t.test('no nesting', function (t) {
     npmRun('level1', {cwd: level[0]}, function (err, stdout, stderr) {


### PR DESCRIPTION
The documentation says that options are optional for `exec`, but a small thing was missing.

Can't come up with a good way of testing this without passing options. I've tested it so that it works for calling bins in the root node_modules. But not for the test bins as I can't set the cwd.

Do you have a idea on how to test this?