### PR TITLE
[#16] Resolve node security advisory 310

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,15 +2,12 @@
 
 var npmPath = require('npm-path')
 var childProcess = require('child_process')
-var syncExec = require('sync-exec')
 var spawn = require('cross-spawn')
 
 var exec = childProcess.exec
 
 // polyfill for childProcess.execSync
-var execSync = childProcess.execSync || function (args, path) {
-  return syncExec(args, path).stdout
-}
+var execSync = childProcess.execSync
 
 npmExec.spawn = npmSpawn
 npmExec.spawnSync = npmSpawnSync

--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "minimist": "^1.2.0",
     "npm-path": "^2.0.3",
     "npm-which": "^3.0.1",
-    "serializerr": "^1.0.3",
-    "sync-exec": "^0.6.2"
+    "serializerr": "^1.0.3"
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
Resolves [#16](https://github.com/timoxley/npm-run/issues/16) by removing the syncExec polyfill.