### PR TITLE
[fix] windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+!/test/**/node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
-before_install: npm install npm -g
 node_js:
   - 4
   - 6
   - 8
+  - 10

--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ var npmPath = require('npm-path')
 var childProcess = require('child_process')
 
 var exec = childProcess.exec
-var spawn = childProcess.spawn
-var spawnSync = childProcess.spawnSync
+var spawn = require('cross-spawn')
+var spawnSync = spawn.sync
 
 // polyfill for childProcess.execSync
 var execSync = childProcess.execSync

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "tape": "^4.9.0"
   },
   "dependencies": {
+    "cross-spawn": "^6.0.5",
     "minimist": "^1.2.0",
     "npm-path": "^2.0.4",
     "npm-which": "^3.0.1",

--- a/test/bin.js
+++ b/test/bin.js
@@ -5,7 +5,7 @@ var bl = require('bl')
 var fs = require('fs')
 
 var path = require('path')
-var spawn = require('child_process').spawn
+var spawn = require('cross-spawn')
 
 var level0 = path.join(__dirname, 'fixtures', 'level0')
 var level1 = path.join(level0, 'node_modules', 'level1')

--- a/test/exec.js
+++ b/test/exec.js
@@ -35,7 +35,7 @@ test('options are optional', function (t) {
 
   npmRun(badPath, function (err, stdout, stderr) {
     t.ok(err, 'has error')
-    t.equal(err.code, 127)
+    t.equal(err.code, (process.platform === 'win32' ? 1 : 127))
     t.end()
   })
 })

--- a/test/fixtures/level0/node_modules/.bin/level1
+++ b/test/fixtures/level0/node_modules/.bin/level1
@@ -1,4 +1,15 @@
-#!/usr/bin/env node
-var path = require('path')
-if (process.argv.length > 2) console.error(process.argv.slice(2).join(' '))
-console.log(path.basename(__filename))
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/../level1/level1" "$@"
+  ret=$?
+else 
+  node  "$basedir/../level1/level1" "$@"
+  ret=$?
+fi
+exit $ret

--- a/test/fixtures/level0/node_modules/.bin/level1.CMD
+++ b/test/fixtures/level0/node_modules/.bin/level1.CMD
@@ -1,0 +1,7 @@
+@IF EXIST "%~dp0\node.exe" (
+  "%~dp0\node.exe"  "%~dp0\..\level1\level1" %*
+) ELSE (
+  @SETLOCAL
+  @SET PATHEXT=%PATHEXT:;.JS;=;%
+  node  "%~dp0\..\level1\level1" %*
+)

--- a/test/fixtures/level0/node_modules/level1/level1
+++ b/test/fixtures/level0/node_modules/level1/level1
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+var path = require('path')
+if (process.argv.length > 2) console.error(process.argv.slice(2).join(' '))
+console.log(path.basename(__filename))

--- a/test/fixtures/level0/node_modules/level1/node_modules/.bin/level2
+++ b/test/fixtures/level0/node_modules/level1/node_modules/.bin/level2
@@ -1,4 +1,15 @@
-#!/usr/bin/env node
-var path = require('path')
-if (process.argv.length > 2) console.error(process.argv.slice(2).join(' '))
-console.log(path.basename(__filename))
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/../level2/level2" "$@"
+  ret=$?
+else 
+  node  "$basedir/../level2/level2" "$@"
+  ret=$?
+fi
+exit $ret

--- a/test/fixtures/level0/node_modules/level1/node_modules/.bin/level2.CMD
+++ b/test/fixtures/level0/node_modules/level1/node_modules/.bin/level2.CMD
@@ -1,0 +1,7 @@
+@IF EXIST "%~dp0\node.exe" (
+  "%~dp0\node.exe"  "%~dp0\..\level2\level2" %*
+) ELSE (
+  @SETLOCAL
+  @SET PATHEXT=%PATHEXT:;.JS;=;%
+  node  "%~dp0\..\level2\level2" %*
+)

--- a/test/fixtures/level0/node_modules/level1/node_modules/level2/level2
+++ b/test/fixtures/level0/node_modules/level1/node_modules/level2/level2
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+var path = require('path')
+if (process.argv.length > 2) console.error(process.argv.slice(2).join(' '))
+console.log(path.basename(__filename))


### PR DESCRIPTION
Reinstates the cross-spawn package to fix #19 and more generally fix tests on Windows. Changes the test setup to reflect the NodeJS Windows and Unix installed executable folder and file structure (i.e. `node_modules\.bin\<command-name>.CMD `on Windows and `node_modules/.bin/<command-name>` on Unix).

Note that error code for an unknown command differs on Unix and Windows (127 vs 1) -- I am not sure if additional customization on Windows can allow for the more specific error code.